### PR TITLE
Some README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,42 @@ some projects require a user supplied pin as well as an apikey
 ```python3
 import tvdb_v4_official
 
-tvdb = tvdb_v4_official.TVDB("APIKEY") # tvdb = tvdb_v4.Api("APIKEY", pin="YOUR PIN HERE")
+tvdb = tvdb_v4_official.TVDB("APIKEY")
+# OR:
+# tvdb = tvdb_v4_official.TVDB("APIKEY", pin="YOUR PIN HERE")
 
-# fetching a page of series
-tvdb.get_all_series(0)
+# fetching several pages of series info
+series_list = [ ]
+for j in range(5): # Pages are numbered from 0
+    series_list += tvdb.get_all_series(j)
 
-# fetching a series 
-tvdb.get_series(121361)
+# fetching a series
+series = tvdb.get_series(121361)
 
-# fetching a seasons episodes
-seasons = tvdb.get_series_extended(121361)["seasons"]
-season_one = None
-for season in seasons:
-    if season["number"] == 1:
-        season_one = season
-episodes = tvdb.get_season_extended(season_one["id"])["episodes"]
+# fetching a season's episode list
+series = tvdb.get_series_extended(121361)
+for season in sorted(series["seasons"], key=lambda x: (x["type"]["name"], x["number"])):
+    if season["type"]["name"] == "Aired Order" and season["number"] == 1:
+	season = tvdb.get_season_extended(season["id"])
+	break
+else:
+    season = None
+if season is not None:
+    print(season["episodes"])
+
+# fetch a page of episodes from a series by season_type (type is "default" if unspecified)
+info = tvdb.get_series_episodes(121361, page=0)
+print(info["series"])
+for ep in info["episodes"]:
+    print(ep)
 
 # fetching a movie
-tvdb.get_movie(31) # avengers
+movie = tvdb.get_movie(31) # avengers
 
-# fetching movie's characters
-characters = tvdb.get_movie_extended(31)["characters"]
+# access a movie's characters
+movie = tvdb.get_movie_extended(31)
+for c in movie["characters"]:
+    print(c)
 
 # fetching a person record
 person = tvdb.get_person_extended(characters[0]["peopleId"])


### PR DESCRIPTION
This version of the README.md brings back a few improvements that were recently lost, but also fixes an issue that my prior README had in the season data checking (since the API recently moved the season name down into the type struct):

- Illustrate that the series data is paged.
- Assign fetched data to a var.
- Avoid an api(call)["foo"] idiom so that the user sees that the api call returns the parent object that can be accessed more than once without repeating the api call.
- The season example doesn't accept just any number == 1, but a specific type of season.