### PR TITLE
Allow empty data when checking if data element is missing.

### DIFF
--- a/tvdb_v4_official.py
+++ b/tvdb_v4_official.py
@@ -37,7 +37,7 @@ class Request:
             except:
                 res = { }
         data = res.get("data", None)
-        if data and res.get('status', 'failure') != 'failure':
+        if data is not None and res.get('status', 'failure') != 'failure':
             return data
         msg = res.get('message', None)
         if not msg:


### PR DESCRIPTION
Fix make_request() to allow an empty list through when it is verifying that it got valid json data in the result. Fixes #17.