### PR TITLE
Allow accessing "links" info for the last request

### DIFF
--- a/tvdb_v4_official.py
+++ b/tvdb_v4_official.py
@@ -24,6 +24,7 @@ class Auth:
 class Request:
     def __init__(self, auth_token):
         self.auth_token = auth_token
+        self.links = None
 
     def make_request(self, url):
         req = urllib.request.Request(url)
@@ -38,6 +39,7 @@ class Request:
                 res = { }
         data = res.get("data", None)
         if data and res.get('status', 'failure') != 'failure':
+            self.links = res.get("links", None)
             return data
         msg = res.get('message', None)
         if not msg:
@@ -71,6 +73,9 @@ class TVDB:
         self.auth = Auth(login_url, apikey, pin)
         auth_token = self.auth.get_token()
         self.request = Request(auth_token)
+
+    def get_req_links(self) -> dict:
+        return self.request.links
 
     def get_artwork_statuses(self, meta=None) -> list:
         """Returns a list of artwork statuses"""


### PR DESCRIPTION
- Save off the "links" dict when returning the "data" value.
- Added `get_req_links()` that will return the stashed data for the last request (also visible via tvdb.request.links).
- Value will be None if the last request had no "links" value.
- Fixes #18.